### PR TITLE
fix: enable indirect dependency updates in renovate config

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -21,6 +21,16 @@
       ],
       automerge: true,
     },
+    {
+      // Enable indirect dependency updates for Go modules
+      matchManagers: [
+        'gomod',
+      ],
+      matchDepTypes: [
+        'indirect',
+      ],
+      enabled: true,
+    },
   ],
   customManagers: [
     {


### PR DESCRIPTION
Add package rule to enable indirect Go module dependency updates

- This allows Renovate to update transitive dependencies automatically
- Fixes issue where indirect dependencies were not being updated
- Based on Renovate documentation for enabling indirect updates