### PR TITLE
feat: add WiFi RSSI metric and fix duplicate collectDeviceInfo call

### DIFF
--- a/internal/collectors/slzb_collector.go
+++ b/internal/collectors/slzb_collector.go
@@ -662,15 +662,19 @@ func (sc *SLZBCollector) updateDeviceNetworkMetrics(deviceName string, deviceDat
 		if v, ok := deviceData["wifiSsid"]; ok && v != "" {
 			wifiSsid = v
 		}
+
 		if v, ok := deviceData["wifiIp"]; ok && v != "" {
 			wifiIP = v
 		}
+
 		if v, ok := deviceData["wifiMac"]; ok && v != "" {
 			wifiMac = v
 		}
+
 		if v, ok := deviceData["wifiGate"]; ok && v != "" {
 			wifiGateway = v
 		}
+
 		if v, ok := deviceData["wifiSubnet"]; ok && v != "" {
 			wifiSubnet = v
 		}
@@ -691,11 +695,13 @@ func (sc *SLZBCollector) updateDeviceNetworkMetrics(deviceName string, deviceDat
 		}).Set(wifiConnected)
 
 		rssi := 0.0
+
 		if rssiStr, ok := deviceData["wifiRssi"]; ok {
 			if parsed, err := strconv.ParseFloat(rssiStr, 64); err == nil {
 				rssi = parsed
 			}
 		}
+
 		sc.metrics.SLZBWifiRSSI.With(prometheus.Labels{
 			"device": deviceName,
 		}).Set(rssi)

--- a/internal/collectors/slzb_collector.go
+++ b/internal/collectors/slzb_collector.go
@@ -680,6 +680,7 @@ func (sc *SLZBCollector) updateDeviceNetworkMetrics(deviceName string, deviceDat
 		}
 
 		wifiConnected := 0.0
+
 		if wifiConn, ok := deviceData["wifiConnected"]; ok && wifiConn == "1" {
 			wifiConnected = 1.0
 		}

--- a/internal/collectors/slzb_collector.go
+++ b/internal/collectors/slzb_collector.go
@@ -215,32 +215,6 @@ func (sc *SLZBCollector) collectMetrics(ctx context.Context) {
 
 	totalCollections++
 
-	// Collect device information
-	deviceInfo2Start := time.Now()
-	if sc.collectDeviceInfo(ctx, deviceID) {
-		deviceInfo2Duration := time.Since(deviceInfo2Start).Seconds()
-		if collectorSpan != nil {
-			collectorSpan.SetAttributes(
-				attribute.Float64("device_info_2.duration_seconds", deviceInfo2Duration),
-			)
-			collectorSpan.AddEvent("device_info_collected",
-				attribute.Float64("duration_seconds", deviceInfo2Duration),
-			)
-		}
-
-		successfulCollections++
-	} else {
-		deviceInfo2Duration := time.Since(deviceInfo2Start).Seconds()
-		if collectorSpan != nil {
-			collectorSpan.SetAttributes(
-				attribute.Float64("device_info_2.duration_seconds", deviceInfo2Duration),
-			)
-			collectorSpan.RecordError(fmt.Errorf("device info collection failed"), attribute.String("device.id", deviceID))
-		}
-	}
-
-	totalCollections++
-
 	// NEW: Collect firmware update status
 	firmwareStart := time.Now()
 	if sc.collectFirmwareStatus(ctx, deviceID) {
@@ -664,6 +638,9 @@ func (sc *SLZBCollector) updateDeviceNetworkMetrics(deviceName string, deviceDat
 			"subnet_mask": "none",
 			"dns_server":  "none",
 		}).Set(0)
+		sc.metrics.SLZBWifiRSSI.With(prometheus.Labels{
+			"device": deviceName,
+		}).Set(0)
 		slog.Info("Ethernet connected from device info", "device", deviceName, "ip", ipAddr, "mac", macAddr, "gateway", gateway, "subnet", subnet, "dns", dns, "speed", speedMbps)
 	} else {
 		sc.metrics.SLZBEthernetConnected.With(prometheus.Labels{
@@ -675,16 +652,55 @@ func (sc *SLZBCollector) updateDeviceNetworkMetrics(deviceName string, deviceDat
 			"dns_server":  "unknown",
 			"speed_mbps":  "unknown",
 		}).Set(0)
+
+		wifiSsid := "unknown"
+		wifiIP := "unknown"
+		wifiMac := "unknown"
+		wifiGateway := "unknown"
+		wifiSubnet := "unknown"
+
+		if v, ok := deviceData["wifiSsid"]; ok && v != "" {
+			wifiSsid = v
+		}
+		if v, ok := deviceData["wifiIp"]; ok && v != "" {
+			wifiIP = v
+		}
+		if v, ok := deviceData["wifiMac"]; ok && v != "" {
+			wifiMac = v
+		}
+		if v, ok := deviceData["wifiGate"]; ok && v != "" {
+			wifiGateway = v
+		}
+		if v, ok := deviceData["wifiSubnet"]; ok && v != "" {
+			wifiSubnet = v
+		}
+
+		wifiConnected := 0.0
+		if wifiConn, ok := deviceData["wifiConnected"]; ok && wifiConn == "1" {
+			wifiConnected = 1.0
+		}
+
 		sc.metrics.SLZBWifiConnected.With(prometheus.Labels{
 			"device":      deviceName,
-			"ssid":        "unknown",
-			"ip_address":  "unknown",
-			"mac_address": "unknown",
-			"gateway":     "unknown",
-			"subnet_mask": "unknown",
-			"dns_server":  "unknown",
-		}).Set(0)
-		slog.Info("Ethernet disconnected from device info", "device", deviceName)
+			"ssid":        wifiSsid,
+			"ip_address":  wifiIP,
+			"mac_address": wifiMac,
+			"gateway":     wifiGateway,
+			"subnet_mask": wifiSubnet,
+			"dns_server":  wifiGateway,
+		}).Set(wifiConnected)
+
+		rssi := 0.0
+		if rssiStr, ok := deviceData["wifiRssi"]; ok {
+			if parsed, err := strconv.ParseFloat(rssiStr, 64); err == nil {
+				rssi = parsed
+			}
+		}
+		sc.metrics.SLZBWifiRSSI.With(prometheus.Labels{
+			"device": deviceName,
+		}).Set(rssi)
+
+		slog.Info("Ethernet disconnected from device info", "device", deviceName, "wifi_ssid", wifiSsid, "wifi_rssi", rssi)
 	}
 }
 

--- a/internal/metrics/slzb_registry.go
+++ b/internal/metrics/slzb_registry.go
@@ -22,6 +22,7 @@ type SLZBRegistry struct {
 	SLZBHeapRatio         *prometheus.GaugeVec
 	SLZBEthernetConnected *prometheus.GaugeVec
 	SLZBWifiConnected     *prometheus.GaugeVec
+	SLZBWifiRSSI          *prometheus.GaugeVec
 
 	// HTTP request metrics (exporter's requests to SLZB device)
 	SLZBHTTPRequestsTotal *prometheus.CounterVec
@@ -168,6 +169,16 @@ func NewSLZBRegistry(baseRegistry *promexporter_metrics.Registry) *SLZBRegistry 
 	)
 
 	baseRegistry.AddMetricInfo("slzb_device_wifi_connected", "SLZB device WiFi connection status (1=connected, 0=disconnected)", []string{"device", "ssid", "ip_address", "mac_address", "gateway", "subnet_mask", "dns_server"})
+
+	slzb.SLZBWifiRSSI = factory.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "slzb_device_wifi_rssi_dbm",
+			Help: "SLZB device WiFi signal strength in dBm",
+		},
+		[]string{"device"},
+	)
+
+	baseRegistry.AddMetricInfo("slzb_device_wifi_rssi_dbm", "SLZB device WiFi signal strength in dBm", []string{"device"})
 
 	slzb.SLZBHTTPRequestsTotal = factory.NewCounterVec(
 		prometheus.CounterOpts{


### PR DESCRIPTION
## Summary
- Removes duplicate `collectDeviceInfo` call that was doubling HTTP requests to the SLZB device per scrape cycle
- Adds `slzb_device_wifi_rssi_dbm` gauge metric for WiFi signal strength in dBm
- Populates WiFi connection labels (ssid, ip, mac, gateway, subnet) with real device data instead of "unknown" when ethernet is not connected
- Sets WiFi RSSI to 0 when device is on ethernet

## Test plan
- [ ] CI passes
- [ ] Verify single HTTP request per scrape when watching logs
- [ ] `slzb_device_wifi_rssi_dbm` metric appears in /metrics when device is on WiFi