### PR TITLE
fix: remove trailing blank line in commits.yml

### DIFF
--- a/.github/workflows/commits.yml
+++ b/.github/workflows/commits.yml
@@ -13,4 +13,3 @@ jobs:
           fetch-depth: 0
 
       - uses: aevea/commitsar@909c3ab676c9af63cb84f2e38f395c7e89829b04 # v1.0.3
-


### PR DESCRIPTION
Remove trailing blank line flagged by yamllint (`empty-lines` rule).